### PR TITLE
Replace usages of List with Collection

### DIFF
--- a/Client/src/main/java/org/gusdb/oauth2/client/veupathdb/OAuthQuerier.java
+++ b/Client/src/main/java/org/gusdb/oauth2/client/veupathdb/OAuthQuerier.java
@@ -1,7 +1,7 @@
 package org.gusdb.oauth2.client.veupathdb;
 
+import java.util.Collection;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -18,23 +18,23 @@ public class OAuthQuerier {
 
   private static final Logger LOG = LogManager.getLogger(OAuthQuerier.class);
 
-  public static Map<String, User> getUsersByEmail(OAuthClient client, OAuthConfig config, List<String> emails) {
+  public static Map<String, User> getUsersByEmail(OAuthClient client, OAuthConfig config, Collection<String> emails) {
     return getUsersByEmail(client, config, emails, BasicUser::new);
   }
 
-  public static <T extends User> Map<String, T> getUsersByEmail(OAuthClient client, OAuthConfig config, List<String> emails, Function<JSONObject, T> userConverter) {
+  public static <T extends User> Map<String, T> getUsersByEmail(OAuthClient client, OAuthConfig config, Collection<String> emails, Function<JSONObject, T> userConverter) {
     return getUsers(client, config, emails, userConverter, "emails", u -> u.getString(IdTokenFields.email.name()));
   }
 
-  public static Map<Long, User> getUsersById(OAuthClient client, OAuthConfig config, List<Long> userIds) {
+  public static Map<Long, User> getUsersById(OAuthClient client, OAuthConfig config, Collection<Long> userIds) {
     return getUsersById(client, config, userIds, BasicUser::new);
   }
 
-  public static <T extends User> Map<Long, T> getUsersById(OAuthClient client, OAuthConfig config, List<Long> userIds, Function<JSONObject, T> userConverter) {
+  public static <T extends User> Map<Long, T> getUsersById(OAuthClient client, OAuthConfig config, Collection<Long> userIds, Function<JSONObject, T> userConverter) {
     return getUsers(client, config, userIds, userConverter, "userIds", u -> Long.valueOf(u.getString(IdTokenFields.sub.name())));
   }
 
-  private static <T extends User, S> Map<S, T> getUsers(OAuthClient client, OAuthConfig config, List<S> identifiers,
+  private static <T extends User, S> Map<S, T> getUsers(OAuthClient client, OAuthConfig config, Collection<S> identifiers,
       Function<JSONObject, T> userConverter, String identifiersJsonPropKey, Function<JSONObject,S> keyGenerator) {
     LOG.info("Using OAuthQuerier for multi-user request by " + identifiersJsonPropKey +
         ": [" + identifiers.stream().map(String::valueOf).collect(Collectors.joining(", ")) + "]");


### PR DESCRIPTION
to support other collection types, such as Sets without requiring callers to do an unnecessary conversion.

Gathering user IDs from a stream of records into a Set is a common use case.